### PR TITLE
chore: Update CI and release workflow templates

### DIFF
--- a/workflow-templates/ci.yml
+++ b/workflow-templates/ci.yml
@@ -11,7 +11,7 @@ jobs:
       should-skip-job: ${{steps.skip-check.outputs.should_skip}}
     steps:
       - id: skip-check
-        uses: fkirc/skip-duplicate-actions@v2.1.0
+        uses: fkirc/skip-duplicate-actions@v5.3.0
         with:
           github_token: ${{github.token}}
 
@@ -30,10 +30,10 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
     - name: checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: read node version from .nvmrc
-      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
       shell: bash
       id: nvm
 
@@ -47,7 +47,7 @@ jobs:
       run: pulseaudio -D
 
     - name: setup node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '${{steps.nvm.outputs.NVMRC}}'
         cache: npm
@@ -61,12 +61,12 @@ jobs:
       run: npm i --prefer-offline --no-audit
 
     - name: run npm test
-      uses: GabrielBB/xvfb-action@v1
+      uses: coactions/setup-xvfb@v1
       with:
         run: npm run test
 
     - name: coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         files: './test/dist/coverage/coverage-final.json'

--- a/workflow-templates/release.yml
+++ b/workflow-templates/release.yml
@@ -15,19 +15,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         # We neeed to fetch the entire history as conventional-changelog needs
         # access to any number of git commits to build the changelog.
         with:
           fetch-depth: 0
 
       - name: read node version from .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         shell: bash
         id: nvm
 
       - name: setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '${{steps.nvm.outputs.NVMRC}}'
           cache: npm
@@ -44,7 +44,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check if this is a pre-release
-        run: echo ::set-output name=IS_PRE_RELEASE::$(npx -p not-prerelease is-prerelease && echo "true" || echo "false")
+        run: echo "IS_PRE_RELEASE=$(npx -p not-prerelease is-prerelease && echo "true" || echo "false")" >> $GITHUB_OUTPUT
         id: pre-release-check
 
       - name: truncate CHANGELOG.md so that we can get the current versions changes only
@@ -54,7 +54,7 @@ jobs:
         run: npx -p @videojs/update-changelog vjs-update-changelog --run-on-prerelease
 
       - name: get dashed package version for netlify
-        run: echo ::set-output name=VERSION::$(node -e "process.stdout.write(require('./package.json').version.split('.').join('-'))")
+        run: echo "VERSION=$(node -e "process.stdout.write(require('./package.json').version.split('.').join('-'))")" >> $GITHUB_OUTPUT
         id: get-version
         shell: bash
         if: env.NETLIFY_BASE != ''


### PR DESCRIPTION
Updated workflows based on this PR https://github.com/videojs/video.js/pull/8214

* Update deprecated set-output command. This will stop working in June 2023. See [this post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
* Update actions to use Node 16 rather than Node 12. Github are currently migrating away from Node 12. See [this post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
* `GabrielBB/xvfb-action` is no longer maintained and there is no Node 16 version. Therefore it was replaced with `coactions/setup-xvfb`.

